### PR TITLE
Update Istio version to latest

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,11 +24,11 @@ startTime=$(timer)
 
 
 
-if [ !  -d "istio-0.5.1" ]; then
+if [ !  -d "istio-0.6.0" ]; then
 	curl -L https://git.io/getLatestIstio | sh -
 fi
 
-cd istio-0.5.1
+cd istio-0.6.0
 export PATH=$PWD/bin:$PATH
 
 ACTION=apply


### PR DESCRIPTION
Current version is 0.6.0; this script fails due to the mismatch.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>